### PR TITLE
fix for adding comments from admin

### DIFF
--- a/zero-spam.php
+++ b/zero-spam.php
@@ -107,7 +107,7 @@ class Zero_Spam {
      * @link http://codex.wordpress.org/Plugin_API/Filter_Reference/preprocess_comment
      */
     public function preprocess_comment( $commentdata ) {
-        if( ! isset ( $_POST['zero-spam'] ) && ! current_user_can( 'moderate_comments' ) ) {
+        if( ! isset ( $_POST['zero-spam'] ) || ! current_user_can( 'moderate_comments' ) ) {
           die( __('There was a problem processing your comment.', 'zerospam') );
         }
         return $commentdata;


### PR DESCRIPTION
With this patch the admin user or whichever user can 'moderate_comments' will be able to add or modify comments from the dashboard. Refer to http://wordpress.org/support/topic/small-bug-11?replies=2
