### PR TITLE
Use unminifed JS if WP_DEBUG is set

### DIFF
--- a/zero-spam.php
+++ b/zero-spam.php
@@ -140,7 +140,11 @@ class Zero_Spam {
      * @link http://codex.wordpress.org/Function_Reference/wp_enqueue_script
      */
     public function wp_enqueue_scripts() {
-        wp_enqueue_script( 'zero-spam', plugins_url( '/zero-spam.min.js' , __FILE__ ), array( 'jquery' ), '1.1.0', true );
+        if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+            wp_enqueue_script( 'zero-spam', plugins_url( '/zero-spam.js' , __FILE__ ), array( 'jquery' ), '1.1.0', true );
+        } else {
+            wp_enqueue_script( 'zero-spam', plugins_url( '/zero-spam.min.js' , __FILE__ ), array( 'jquery' ), '1.1.0', true );
+        }
     }
 }
 


### PR DESCRIPTION
This patch modifies the plugin to use the unminified JS if the WP_DEBUG constant is defined making development easier.
