### PR TITLE
CF7 support

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -46,10 +46,11 @@ Be sure JavaScript is enabled and there are no JS errors.
 
 = Can I extend the plugin with action hooks? =
 
-Yes, currently there's two hooks available:
+Yes, currently there are three hooks available:
 
 * `zero_spam_found_spam_registration` - Runs after a spam registration is detected
 * `zero_spam_found_spam_comment` - Runs after a spam comment is detected
+* `zero_spam_found_spam_cf7_form_submission` - Runs after a spam contact form 7 form submission is detected
 
 == Screenshots ==
 

--- a/zero-spam.js
+++ b/zero-spam.js
@@ -13,7 +13,7 @@
 ( function( $ ) {
     'use strict';
 
-    var forms = "#commentform, #registerform";
+    var forms = "#commentform, #registerform, .wpcf7-form";
 
     if ( typeof zerospam.nonce != 'undefined') {
       $( forms ).submit( function() {

--- a/zero-spam.php
+++ b/zero-spam.php
@@ -266,6 +266,7 @@ class Zero_Spam {
         add_action( 'wp_enqueue_scripts', array( &$this, 'wp_enqueue_scripts' ) );
         add_action( 'login_footer', array( &$this, 'wp_enqueue_scripts' ) );
         add_action( 'preprocess_comment', array( &$this, 'preprocess_comment' ) );
+        add_action( 'wpcf7_validate', array( $this, 'wpcf7_validate' ) );
 
         if( $this->settings['zerospam_general_settings']['wp_generator'] == 'remove' ) {
             remove_action( 'wp_head', 'wp_generator' );
@@ -340,6 +341,24 @@ class Zero_Spam {
             $errors->add( 'spam_error', __( $this->settings['zerospam_general_settings']['spammer_msg_registration'], 'zerospam' ) );
         }
         return $errors;
+    }
+
+     /**
+     * Validate Contact Form 7 (https://wordpress.org/plugins/contact-form-7/) form submissions.
+     *
+     * Validates the contact form 7 form submission, and flags the form submission as invalid if
+     * the zero-spam post data isn't present.
+     *
+     * @since  1.5.0
+     *
+     */
+    public function wpcf7_validate( $result ) {
+        if ( ! wp_verify_nonce( $_POST['zero-spam'], 'zerospam' ) ) {
+            do_action( 'zero_spam_found_spam_cf7_form_submission' );
+            $result['valid'] = false;
+            $result['reason']['zero_spam'] = __( 'There was a problem with your form submission.', 'zerospam' );
+        }
+        return $result;
     }
 
     /**


### PR DESCRIPTION
This PR modifies the plugin to support protecting Contact Form 7 forms (http://wordpress.org/plugins/contact-form-7/).
