### PR TITLE
#47. Added the ability to control where spam detection gets ran.

### DIFF
--- a/src/scss/style.scss
+++ b/src/scss/style.scss
@@ -284,6 +284,10 @@ $border-color: #e8edf1;
   .zerospam__right {
     width: 100%;
     float: none;
+
+    .zero-spam__widget:first-child {
+      margin-top: 0;
+    }
   }
 }
 


### PR DESCRIPTION
Ticket: https://github.com/bmarshall511/wordpress-zero-spam/issues/47
