### PR TITLE
Bug fix: install/activation routine would never run

### DIFF
--- a/lib/ZeroSpam/Install.php
+++ b/lib/ZeroSpam/Install.php
@@ -63,7 +63,7 @@ class ZeroSpam_Install extends ZeroSpam_Plugin
    * @see update_option
    * @global string ZEROSPAM_PLUGIN The plugin root directory.
    */
-  private function activate()
+  public function activate()
   {
     // Install the DB tables.
     $this->install();


### PR DESCRIPTION
WordPress hooks are callbacks. Callback can only call `public` methods in a class when they are called from outside of the class - as is the case for hooks -.

In other words, the `activate()` method would never run and would throw a PHP warning `'call_user_func_array() expects parameter 1 to be a valid callback, cannot access private method ZeroSpam_Install::activate()`, which would go unnoticed in most cases as PHP errors are normally hidden in active sites.

Fixes:
* https://wordpress.org/support/topic/activation-error-78/
* https://wordpress.org/support/topic/plugin-is-generating-errors/
* https://wordpress.org/support/topic/plugin-activation-error-17/