### PR TITLE
Bug fix: option may not be set

### DIFF
--- a/lib/ZeroSpam/Admin.php
+++ b/lib/ZeroSpam/Admin.php
@@ -370,7 +370,7 @@ class ZeroSpam_Admin extends ZeroSpam_Plugin {
   public function field_blocked_ip_msg() {
     ?>
     <label for="blocked_ip_msg">
-      <input type="text" class="regular-text" name="zerospam_general_settings[blocked_ip_msg]" value="<?php echo esc_attr( $this->settings['blocked_ip_msg'] ); ?>">
+      <input type="text" class="regular-text" name="zerospam_general_settings[blocked_ip_msg]" value="<?php echo esc_attr( isset( $this->settings['blocked_ip_msg'] ) ? $this->settings['blocked_ip_msg'] : '' ); ?>">
     <p class="description"><?php echo __( 'Enter a short message to display when a blocked IP visits the site.', 'zerospam' ); ?></p>
     </label>
     <?php


### PR DESCRIPTION
As the install routine will not have run for any of the installs in the past two and half years, the default settings may not have been set.

For this particular setting, this was causing an `Undefined index: blocked_ip_msg` PHP notice to be thrown.

This minor change fixes that.

Fixes #147

Fixes:
* https://wordpress.org/support/topic/notice-undefined-index-blocked_ip_msg/