### PR TITLE
Add Composer config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ tmp
 js-dev
 css-dev
 img-dev
+/vendor/

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,22 @@
+{
+    "name"        : "bmarshall511/wordpress-zero-spam",
+    "description" : "Zero Spam makes blocking spam comments a cinch. Install, activate and enjoy a spam-free site. Even supports third-party plugins!",
+    "keywords"    : ["wordpress", "plugin" ],
+    "type"        : "wordpress-plugin",
+    "license"     : "GPL-2.0-or-later",
+    "authors": [
+        {
+            "name"    : "Ben Marshall",
+            "homepage": "https://github.com/bmarshall511"
+        }
+    ],
+    "support": {
+        "issues": "https://github.com/bmarshall511/wordpress-zero-spam/issues",
+        "source": "https://github.com/bmarshall511/wordpress-zero-spam"
+    },
+    "require": {
+        "php" : ">=5.2",
+    },
+    "minimum-stability" : "RC",
+    "prefer-stable": true
+}


### PR DESCRIPTION
This will allow the plugin to be hosted on [Packagist](http://packagist.org/) and for it to be installed via the PHP dependency manager [Composer](https://getcomposer.org/).

For now, the minimum PHP requirement has been set to PHP 5.2.

Once support for WP < 5.2 has been dropped, this can be upped to PHP 5.6.

---

**Important**: I've based the "package name" - `bmarshall511/wordpress-zero-spam` - off the repo name as it is on GitHub. They don't actually have to be the same and once you add the plugin to Packagist, the name cannot be changed anymore!

Let me know if you'd like to use a different name.

Some possible alternatives:
* `bmarshall/wordpress-zero-spam`
* `benmarshall/wordpress-zero-spam`
* `marshall/wordpress-zero-spam`

Also see: https://packagist.org/about#naming-your-package

Please let me know if you have questions about getting set up on Packagist.