### PR TITLE
Readme: add minimum PHP version tag

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,6 +5,7 @@ Tags: comments, spam, antispam, anti-spam, comment spam, spambot, spammer, spam 
 Requires at least: 3.0.0
 Tested up to: 5.2.1
 Stable tag: 3.1.0
+Requires PHP: 5.2.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
Make the minimum PHP version requirement explicit.

Ref: https://make.wordpress.org/plugins/2017/08/29/minimum-php-version-requirement/