### PR TITLE
Bug fix: fix parse error

### DIFF
--- a/tpl/block-ip-form.php
+++ b/tpl/block-ip-form.php
@@ -94,7 +94,7 @@ defined( 'ABSPATH' ) or die( 'No script kiddies please!' );
 </table>
 <p class="submit">
     <input type="submit" value="<?php echo __( 'Save Changes', 'zerospam' ); ?>" class="button button-primary button-large">
-    <? if ( $ip ): ?><a href="javascript: closeForms();" class="button button-large"><?php echo __( 'Close', 'zerospam' ); ?></a><?php endif; ?>
+    <?php if ( $ip ): ?><a href="javascript: closeForms();" class="button button-large"><?php echo __( 'Close', 'zerospam' ); ?></a><?php endif; ?>
 </p>
 </form>
 <script>
@@ -116,7 +116,7 @@ jQuery( document ).ready( function( $ ) {
 
       form.prepend( "<div class='zero-spam__msg'>This IP address has been updated.</div>" );
 
-      <? if ( $ip ): ?>updateRow( '<?php echo $ip; ?>' );<?php endif; ?>
+      <?php if ( $ip ): ?>updateRow( '<?php echo $ip; ?>' );<?php endif; ?>
     });
   });
 


### PR DESCRIPTION
PHP short open tags are only supported when the PHP ini directive `short_open_tag` is set to `true` or if PHP was configured with the `--enable-short-tags` option.

Using them is discouraged as it will cause PHP to be displayed inline as if it were HTML when support for short open tags is turned off, which could be considered a security risk.

Another reason for it to be discouraged is that it conflicts with XML declarations.

For that reason on a lot of webservers, the setting is turned off by default, so for cross-server compatible code, full PHP open tags need to be used.

Refs:
* https://www.php.net/manual/en/language.basic-syntax.phptags.php
* https://www.php.net/manual/en/ini.core.php#ini.short-open-tag