### PR TITLE
Add a configuration for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,42 @@
+# Travis CI (MIT License) configuration file.
+# @link https://travis-ci.org/
+
+dist: trusty
+
+# Declare project language.
+# @link http://about.travis-ci.org/docs/user/languages/php/
+language: php
+
+# Declare versions of PHP to use. Use one decimal max.
+# @link http://docs.travis-ci.com/user/build-configuration/
+php:
+  - 5.6
+  - 7.0
+  - 7.3
+  - "7.4snapshot"
+
+matrix:
+  fast_finish: true
+
+  include:
+    - php: 5.3
+      dist: precise
+    - php: 5.2
+      dist: precise
+
+  allow_failures:
+    - php: "7.4snapshot"
+
+# Use this to prepare the system to install prerequisites or dependencies.
+# e.g. sudo apt-get update.
+# Failures in this section will result in build status 'errored'.
+before_install:
+  # Speed up build time by disabling Xdebug when its not needed.
+  - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
+
+# Run test script commands.
+# Default is specific to project language.
+# All commands must exit with code 0 on success. Anything else is considered failure.
+script:
+  # Check for PHP syntax errors.
+  - if find . -path ./vendor -prune -o -path ./grunt -prune -o -name "*.php" -exec php -l {} \; | grep "^[Parse error|Fatal error]"; then exit 1; fi


### PR DESCRIPTION
This adds a minimal configuration for Travis CI which, for now, just does a basic QA check:
* It checks that the PHP code does not contain any parse errors on select high/low PHP versions for each PHP major.

For this to work, Travis CI needs to be turned on for this repo. (free for open source)
See this tutorial: https://docs.travis-ci.com/user/tutorial/

Once this PR has been merged and Travis CI activated for this repo, the script will run on each PR to prevent parse errors from entering the repo.