### PR TITLE
CS: don't use inline control structures

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -357,10 +357,14 @@ function zerospam_parse_spam_ary( $ary ) {
       $return['by_date'][ substr( $obj->date, 0, 10 ) ]['wpf_spam']++;
       $return['wpf_spam']++;
     } else {
-      if ( empty(  $return['by_date'][ substr( $obj->date, 0, 10 ) ][$obj->type] ) )  $return['by_date'][ substr( $obj->date, 0, 10 ) ][$obj->type] = 0;
+      if ( empty(  $return['by_date'][ substr( $obj->date, 0, 10 ) ][$obj->type] ) ) {
+        $return['by_date'][ substr( $obj->date, 0, 10 ) ][$obj->type] = 0;
+      }
       $return['by_date'][ substr( $obj->date, 0, 10 ) ][$obj->type]++;
 
-      if ( empty( $return[$obj->type] ) ) $return[$obj->type] = 0;
+      if ( empty( $return[$obj->type] ) ) {
+        $return[$obj->type] = 0;
+      }
       $return[$obj->type]++;
     }
 

--- a/tpl/spammer-logs.php
+++ b/tpl/spammer-logs.php
@@ -262,7 +262,10 @@ defined( 'ABSPATH' ) or die( 'No script kiddies please!' );
             $cnt = 0;
 
             foreach( $all_spam['by_spam_count'] as $ip => $count ):
-              $cnt++; if ( $cnt > 6) break;
+              $cnt++;
+              if ( $cnt > 6) {
+                break;
+              }
               ?>
               <tr data-ip="<?php echo $ip; ?>">
                 <td><a href="http://ip-lookup.net/index.php?ip=<?php echo $ip; ?>" target="_blank">


### PR DESCRIPTION
[Part of CS fixing PR series]

Control structures without curly braces are terribly bug prone as people often don't realize that they only apply to the first statement following the control structure.

Best practice is to always use braces.