### PR TITLE
QA: remove redundant security check

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -9,11 +9,6 @@
  * @since 1.0.0
  */
 
-/**
- * Security Note: Blocks direct access to the plugin PHP files.
- */
-defined( 'ABSPATH' ) or die( 'No script kiddies please!' );
-
 function zerospam_settings() {
   if ( is_plugin_active_for_network( plugin_basename( ZEROSPAM_PLUGIN ) ) ) {
     // Network plugin settings.

--- a/lib/ZeroSpam/Comments.php
+++ b/lib/ZeroSpam/Comments.php
@@ -10,11 +10,6 @@
  */
 
 /**
- * Security Note: Blocks direct access to the plugin PHP files.
- */
-defined( 'ABSPATH' ) or die( 'No script kiddies please!' );
-
-/**
  * Processes comments.
  *
  * This library process user comments and checks for spam.

--- a/lib/ZeroSpam/Install.php
+++ b/lib/ZeroSpam/Install.php
@@ -10,11 +10,6 @@
  */
 
 /**
- * Security Note: Blocks direct access to the plugin PHP files.
- */
-defined( 'ABSPATH' ) or die( 'No script kiddies please!' );
-
-/**
  * Installs the Zero Spam plugin.
  *
  * This library creates all of the required tables and sets the initial

--- a/lib/ZeroSpam/Plugin.php
+++ b/lib/ZeroSpam/Plugin.php
@@ -10,11 +10,6 @@
  */
 
 /**
- * Security Note: Blocks direct access to the plugin PHP files.
- */
-defined( 'ABSPATH' ) or die( 'No script kiddies please!' );
-
-/**
  * Initializes the Zero Spam plugin.
  *
  * This library creates defines the default settings & initializes all

--- a/lib/ZeroSpam/Scripts.php
+++ b/lib/ZeroSpam/Scripts.php
@@ -10,11 +10,6 @@
  */
 
 /**
- * Security Note: Blocks direct access to the plugin PHP files.
- */
-defined( 'ABSPATH' ) or die( 'No script kiddies please!' );
-
-/**
  * CSS & JS scripts.
  *
  * Registers plugin CSS & JS scripts.


### PR DESCRIPTION
If a file only contains function or class declarations and no code being executed in the global namespace, there is no need for the "security check" as if the file is called, all that will be displayed would be a blank page anyway.