### PR TITLE
CS/QA: review of all include and require statements

### DIFF
--- a/lib/ZeroSpam/Admin.php
+++ b/lib/ZeroSpam/Admin.php
@@ -543,7 +543,7 @@ class ZeroSpam_Admin extends ZeroSpam_Plugin {
         /**
          * Include the admin sidebar.
          */
-        require_once( ZEROSPAM_ROOT . 'tpl' . DIRECTORY_SEPARATOR . 'admin-sidebar.php' );
+        require_once ZEROSPAM_ROOT . 'tpl/admin-sidebar.php';
         ?>
         </div>
         <div class="zerospam__left">
@@ -581,7 +581,7 @@ class ZeroSpam_Admin extends ZeroSpam_Plugin {
             /**
              * Include the Spammer Logs page.
              */
-            require_once( ZEROSPAM_ROOT . 'tpl' . DIRECTORY_SEPARATOR . 'spammer-logs.php' );
+            require_once ZEROSPAM_ROOT . 'tpl/spammer-logs.php';
           } elseif ( $tab == 'zerospam_ip_block' ) {
             $limit = 10;
             $args = array(
@@ -593,13 +593,13 @@ class ZeroSpam_Admin extends ZeroSpam_Plugin {
             /**
              * Include the Blocked IPs page.
              */
-            require_once( ZEROSPAM_ROOT . 'tpl' . DIRECTORY_SEPARATOR . 'ip-block.php' );
+            require_once ZEROSPAM_ROOT . 'tpl/ip-block.php';
           } else {
 
             /**
              * General settings page template.
              */
-            require_once( ZEROSPAM_ROOT . 'tpl' . DIRECTORY_SEPARATOR . 'general-settings.php' );
+            require_once ZEROSPAM_ROOT . 'tpl/general-settings.php';
           } ?>
         </div>
 

--- a/lib/ZeroSpam/Ajax.php
+++ b/lib/ZeroSpam/Ajax.php
@@ -109,7 +109,7 @@ class ZeroSpam_Ajax extends ZeroSpam_Plugin {
     /**
      * Include the block IP form.
      */
-    require_once( ZEROSPAM_ROOT . 'tpl' . DIRECTORY_SEPARATOR . 'block-ip-form.php' );
+    require_once ZEROSPAM_ROOT . 'tpl/block-ip-form.php';
 
     die();
   }

--- a/lib/ZeroSpam/Install.php
+++ b/lib/ZeroSpam/Install.php
@@ -156,7 +156,7 @@ class ZeroSpam_Install extends ZeroSpam_Plugin
          * Rather than executing an SQL query directly, we'll use the dbDelta
          * function in wp-admin/includes/upgrade.php.
          */
-        require_once( ABSPATH . 'wp-admin/includes/upgrade.php' );
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
         dbDelta( $sql );
       }
 

--- a/zero-spam.php
+++ b/zero-spam.php
@@ -44,12 +44,12 @@ if( ! defined( 'ZEROSPAM_PLUGIN ' ) )
 /**
  * Include the plugin helpers.
  */
-require_once( ZEROSPAM_ROOT . 'inc' . DIRECTORY_SEPARATOR . 'helpers.php' );
+require_once ZEROSPAM_ROOT . 'inc/helpers.php';
 
 /**
  * Used to detect installed plugins.
  */
-require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+require_once ABSPATH . 'wp-admin/includes/plugin.php';
 
 spl_autoload_register( 'zerospam_autoloader' );
 


### PR DESCRIPTION
`include` and `require` are language constructs, not functions.

With that in mind there are a number of best practices surrounding them:
* There is no need to use parenthesis and not doing so will be, albeit marginally, faster.
* Always pass an absolute path for maximum portability. :heavy_check_mark:
* As all the relevant PATH constants already contain a trailing slash, there is no need for a slash at the start of the text string pointing to the exact file to be included. :heavy_check_mark:
* Using the `DIRECTORY_SEPARATOR` constant is not necessary for include/require statements. Using a forward-slash will work fine on all OS-es.