### PR TITLE
CS: comma after last array item in multiline arrays

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -121,7 +121,7 @@ function zerospam_log_spam( $key, $url = false ) {
     zerospam_block_ip( array(
       'ip'     => $ip,
       'type'   => 'permanent',
-      'reason' => __( 'Auto block triggered on ', 'zerospam' ) . date( 'r' ) . '.'
+      'reason' => __( 'Auto block triggered on ', 'zerospam' ) . date( 'r' ) . '.',
     ));
   }
 }
@@ -284,7 +284,7 @@ function zerospam_parse_spam_ary( $ary ) {
       'Wed' => 0,
       'Thu' => 0,
       'Fri' => 0,
-      'Sat' => 0
+      'Sat' => 0,
     ),
   );
 
@@ -394,7 +394,7 @@ function zerospam_all_spam_ary() {
       'Wed' => 0,
       'Thu' => 0,
       'Fri' => 0,
-      'Sat' => 0
+      'Sat' => 0,
     ),
   );
 
@@ -417,7 +417,8 @@ function zerospam_all_spam_ary() {
     4                => 'gf_spam',
     5                => 'bp_registration_spam',
     'nf'             => 'nf_spam',
-    'Undefined Form' =>  'undefined_form' );
+    'Undefined Form' =>  'undefined_form',
+  );
 
   // Get spammers by weekday.
   $by_weekday_ary = $wpdb->get_results( "SELECT DATE_FORMAT(date, '%a') as day, COUNT(*) num FROM $table_name GROUP BY day", ARRAY_A );
@@ -472,7 +473,7 @@ function zerospam_all_spam_ary() {
             'cf7_spam'             => 0,
             'gf_spam'              => 0,
             'bp_registration_spam' => 0,
-            'nf_spam'              => 0
+            'nf_spam'              => 0,
         );
       }
       $return['by_date'][ $ary['day'] ][ $type_map[ $ary['type'] ] ] = $ary['num'];
@@ -658,7 +659,7 @@ function zerospam_get_ip_info( $ip ) {
           'latitude'      => $data->latitude,
           'longitude'     => $data->longitude,
           'metro_code'    => $data->metro_code,
-          'area_code'     => $data->area_code
+          'area_code'     => $data->area_code,
         ),
         array(
           '%s',
@@ -671,7 +672,7 @@ function zerospam_get_ip_info( $ip ) {
           '%d',
           '%d',
           '%d',
-          '%d'
+          '%d',
         )
       );
     }

--- a/lib/ZeroSpam/Admin.php
+++ b/lib/ZeroSpam/Admin.php
@@ -557,7 +557,7 @@ class ZeroSpam_Admin extends ZeroSpam_Plugin {
             $limit = 10;
             $args = array(
               'limit' => $limit,
-              'offset' => ($page - 1) * $limit
+              'offset' => ($page - 1) * $limit,
             );
             $spam            = zerospam_get_spam( $args );
             $spam            = zerospam_parse_spam_ary( $spam );
@@ -586,7 +586,7 @@ class ZeroSpam_Admin extends ZeroSpam_Plugin {
             $limit = 10;
             $args = array(
               'limit' => $limit,
-              'offset' => ($page - 1) * $limit
+              'offset' => ($page - 1) * $limit,
             );
             $ips = zerospam_get_blocked_ips( $args );
 

--- a/lib/ZeroSpam/Ajax.php
+++ b/lib/ZeroSpam/Ajax.php
@@ -215,7 +215,7 @@ class ZeroSpam_Ajax extends ZeroSpam_Plugin {
     $spam = $spam['by_spam_count'];
     $return = array(
       'by_country' => array(),
-      'by_lat_long' => array()
+      'by_lat_long' => array(),
     );
 
     // API usage limit protection.
@@ -233,7 +233,7 @@ class ZeroSpam_Ajax extends ZeroSpam_Plugin {
         if ( ! isset( $return['by_country'][ $loc->country_code ] ) ) {
           $return['by_country'][ $loc->country_code ] = array(
             'count' => 0,
-            'name' => $loc->country_name
+            'name' => $loc->country_name,
           );
         }
         $return['by_country'][ $loc->country_code ]['count']++;
@@ -242,7 +242,7 @@ class ZeroSpam_Ajax extends ZeroSpam_Plugin {
           $return['by_lat_long'][ $ip ] = array(
             'latLng' => array( $loc->latitude, $loc->longitude ),
             'name' => $loc->country_name,
-            'count' => 1
+            'count' => 1,
           );
         }
       }

--- a/tpl/admin-sidebar.php
+++ b/tpl/admin-sidebar.php
@@ -40,9 +40,9 @@ defined( 'ABSPATH' ) or die( 'No script kiddies please!' );
         __( '<small>If you have suggestions for a new add-on, feel free to email me at <a href="%s">me@benmarshall.me</a>. Want regular updates? Follow me on <a href="%s" target="_blank">Twitter</a> or <a href="%s" target="_blank">visit my blog</a>.</small>', 'zero-spam' ),
         array(
           'a' => array(
-            'href' => array()
+            'href' => array(),
           ),
-          'small' => array()
+          'small' => array(),
         )
       ),
       esc_url( 'mailto:me@benmarshall.me' ),


### PR DESCRIPTION
[Part of CS fixing PR series]

Using a comma after each array item in multi-line arrays is considered best practice.

This makes adding additional items to the array easier and make the `diff` when adding new items clearer.