### PR TITLE
CS: use lowercase for special PHP constants

### DIFF
--- a/inc/helpers.php
+++ b/inc/helpers.php
@@ -677,7 +677,7 @@ function zerospam_get_ip_info( $ip ) {
     }
   }
 
-  if ( FALSE != $data ) {
+  if ( false != $data ) {
     return $data;
   }
 

--- a/lib/ZeroSpam/Ajax.php
+++ b/lib/ZeroSpam/Ajax.php
@@ -52,7 +52,7 @@ class ZeroSpam_Ajax extends ZeroSpam_Plugin {
       ));
     }
 
-    $reason = isset( $_POST['zerospam-reason'] ) ? $_POST['zerospam-reason'] : NULL;
+    $reason = isset( $_POST['zerospam-reason'] ) ? $_POST['zerospam-reason'] : null;
 
     // Add/update the blocked IP.
     zerospam_block_ip( array(


### PR DESCRIPTION
[Part of CS fixing PR series]

It is considered best practice to always use lowercase `true`, `false` and `null`.

This fixes the two cases were this was inconsistent with the rest of the codebase.