### PR TITLE
QA: adjust security check

### DIFF
--- a/tpl/admin-sidebar.php
+++ b/tpl/admin-sidebar.php
@@ -12,7 +12,9 @@
 /**
  * Security Note: Blocks direct access to the plugin PHP files.
  */
-defined( 'ABSPATH' ) or die( 'No script kiddies please!' );
+if ( ! defined( 'ABSPATH' ) ) {
+	exit();
+}
 ?>
 <div class="zero-spam__widget">
   <div class="zero-spam__inner">

--- a/tpl/block-ip-form.php
+++ b/tpl/block-ip-form.php
@@ -8,7 +8,9 @@
 /**
  * Security Note: Blocks direct access to the plugin PHP files.
  */
-defined( 'ABSPATH' ) or die( 'No script kiddies please!' );
+if ( ! defined( 'ABSPATH' ) ) {
+	exit();
+}
 
 $zerospam_year = date( 'Y' );
 ?>

--- a/tpl/general-settings.php
+++ b/tpl/general-settings.php
@@ -8,7 +8,9 @@
 /**
  * Security Note: Blocks direct access to the plugin PHP files.
  */
-defined( 'ABSPATH' ) or die( 'No script kiddies please!' );
+if ( ! defined( 'ABSPATH' ) ) {
+	exit();
+}
 ?>
 <div class="zero-spam__row">
   <div class="zero-spam__widget">

--- a/tpl/ip-block.php
+++ b/tpl/ip-block.php
@@ -1,3 +1,11 @@
+<?php
+/**
+ * Security Note: Blocks direct access to the plugin PHP files.
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit();
+}
+?>
 <div class="zero-spam__row">
   <div class="zero-spam__widget">
     <div class="zero-spam__inner">

--- a/tpl/spammer-logs.php
+++ b/tpl/spammer-logs.php
@@ -12,7 +12,9 @@
 /**
  * Security Note: Blocks direct access to the plugin PHP files.
  */
-defined( 'ABSPATH' ) or die( 'No script kiddies please!' );
+if ( ! defined( 'ABSPATH' ) ) {
+	exit();
+}
 ?>
 <div class="zero-spam__row">
   <div class="zero-spam__cell">

--- a/zero-spam.php
+++ b/zero-spam.php
@@ -28,7 +28,9 @@
 /**
  * Security Note: Blocks direct access to the plugin PHP files.
  */
-defined( 'ABSPATH' ) or die( 'No script kiddies please!' );
+if ( ! defined( 'ABSPATH' ) ) {
+	exit();
+}
 
 // Define constants.
 if( ! defined( 'ZEROSPAM_ROOT ' ) )


### PR DESCRIPTION
When a file will directly generate output when called, the "security check" could be considered valid, though a case can be made that if the file does not make use of any of the request variables, such as `$_GET` or `$_POST` and doesn't do any updates (to the database etc), there is no real harm in the plain HTML skeleton being displayed either.

So, based on that, these checks _could_ be removed.

If they remain, however, let's just fail silently without any indication of why the request failed.