### PR TITLE
Add the ability to uninstall options on Multisite

### DIFF
--- a/wordpress-zero-spam.php
+++ b/wordpress-zero-spam.php
@@ -146,13 +146,33 @@ if ( ! function_exists( 'wpzerospam_uninstall' ) ) {
   function wpzerospam_uninstall() {
     global $wpdb;
 
-    delete_option( 'wpzerospam_key' );
-    delete_option( 'wpzerospam' );
-    delete_option( 'wpzerospam_db_version' );
+    if ( is_multisite() ) {
+      $blogs = $wpdb->get_results( "SELECT blog_id FROM {$wpdb->blogs}", ARRAY_A );
 
-    $tables = wpzerospam_tables();
-    foreach( $tables as $key => $table ) {
-      $wpdb->query( "DROP TABLE IF EXISTS $table" );
+      if ( $blogs ) {
+        foreach ( $blogs as $blog ) {
+          switch_to_blog( $blog['blog_id'] );
+
+          delete_option( 'wpzerospam' );
+          delete_option( 'wpzerospam_key' );
+          delete_option( 'wpzerospam_db_version' );
+
+          $tables = wpzerospam_tables();
+          foreach( $tables as $key => $table ) {
+            $wpdb->query( "DROP TABLE IF EXISTS $table" );
+          }
+        }
+        restore_current_blog();
+      }
+    } else {
+      delete_option( 'wpzerospam' );
+      delete_option( 'wpzerospam_key' );
+      delete_option( 'wpzerospam_db_version' );
+
+      $tables = wpzerospam_tables();
+      foreach( $tables as $key => $table ) {
+        $wpdb->query( "DROP TABLE IF EXISTS $table" );
+      }
     }
   }
 }


### PR DESCRIPTION
When used on Multisite, WordPress Zero Spam only removes the options from the main website.
With this update, the cleanup made on uninstall is performed on all websites from a Multisite network.