### PR TITLE
Fix autoloader compatibility with Windows paths

### DIFF
--- a/includes/class-autoloader.php
+++ b/includes/class-autoloader.php
@@ -74,14 +74,10 @@ class Autoloader {
 	 */
 	private static function load_class( $relative_class_name ) {
 		$filename = strtolower(
-			preg_replace(
-				array( '/_/', '/\\\/' ),
-				array( '', DIRECTORY_SEPARATOR ),
-				$relative_class_name
-			)
+			str_replace( '_', '', $relative_class_name )
 		);
 
-		$filename_parts = explode( '/', $filename );
+		$filename_parts = explode( '\\', $filename );
 		$last_part      = array_key_last( $filename_parts );
 
 		$filename_parts[ $last_part ] = 'class-' . $filename_parts[ $last_part ];


### PR DESCRIPTION
Simplifies autoloader path processing a smidge and fixes compatibility with Windows hosts.

As it stands, the autoloader path resolution process swaps out `\` namespace separators with `DIRECTORY_SEPARATOR` and then `explode()`s on `/` to create an array of path parts - on Windows this results in autoloaded classes failing to resolve, and throwing the error
```bash
Fatal error:  Uncaught Error: Class 'ZeroSpam\Includes\DB' not found in \wp-content\plugins\wordpress-zero-spam\includes\class-plugin.php:144
```