### PR TITLE
fix DB update error for multisite installations

### DIFF
--- a/includes/class-db.php
+++ b/includes/class-db.php
@@ -84,7 +84,7 @@ class DB {
 			require_once ABSPATH . 'wp-admin/includes/upgrade.php';
 			dbDelta( $sql );
 
-			update_option( 'zerospam_db_version', self::DB_VERSION );
+			update_site_option( 'zerospam_db_version', self::DB_VERSION );
 		}
 	}
 


### PR DESCRIPTION
On a multisite installation, the plugin currently uses [`get_site_option()`](https://github.com/bmarshall511/wordpress-zero-spam/blob/ec654c63b0ae74272b3900f2faaaa385f43e7098/includes/class-db.php#L50) to read the current version but [`update_option()`](https://github.com/bmarshall511/wordpress-zero-spam/blob/ec654c63b0ae74272b3900f2faaaa385f43e7098/includes/class-db.php#L87) to set it after the DB update.

In my instance, I had the plugin network-activated, and every pageload resulted in 20s of latency while it ran the DB updates.

Once the DB updates were complete, it would write a site option, but on the next pageload, it would read from the (unset) network option, and run the DB updates again.

This PR resolves the issue by using [`update_site_option()`](https://developer.wordpress.org/reference/functions/update_site_option/) instead, which [falls back](https://github.com/WordPress/wordpress-develop/blob/ba943e113d3b31b121f77a2d30aebe14b047c69d/src/wp-includes/option.php#L1770-L1772) to `update_option()` when not in multisite.