### PR TITLE
fix: update OSPO action references to canonical org path

### DIFF
--- a/.github/workflows/stale_repos.yml
+++ b/.github/workflows/stale_repos.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - name: Run stale_repos tool
-      uses: github/stale-repos@v1
+      uses: github-community-projects/stale-repos@v1
       env:
         GH_TOKEN: ${{ secrets.GH_PAT_REPO }}
         ORGANIZATION: Zero Spam


### PR DESCRIPTION
Updates GitHub Actions workflow references from the legacy `github/` org path to the canonical `github-community-projects/` path.

The following OSPO actions have been transferred to the `github-community-projects` organization:

| Legacy path | Canonical path |
|---|---|
| `github/stale-repos` | `github-community-projects/stale-repos` |

While GitHub's repo redirect ensures the old paths still work today, updating to the canonical path avoids depending on the redirect and ensures long-term stability.

**No functional changes** - the same action versions are referenced.
